### PR TITLE
[feat] level range dropdown for wild encounters

### DIFF
--- a/src/components/CalibrationForm.tsx
+++ b/src/components/CalibrationForm.tsx
@@ -55,6 +55,7 @@ export interface CalibrationFormState {
     wildPokemon: number;
     wildLead: number;
     shouldFilterPokemon: boolean;
+    wildLevel: number;
     method: number;
 }
 
@@ -154,6 +155,7 @@ export default function CalibrationForm({
             wildPokemon: 0,
             wildLead: 255,
             shouldFilterPokemon: false,
+            wildLevel: -1,
             method: 1,
         });
     const {
@@ -354,11 +356,15 @@ export default function CalibrationForm({
                     calibrationFormState.gender,
                     ivRanges,
                     proxy((results: ExtendedWildGeneratorState[]) => {
+                        const levelFilter = calibrationFormState.wildLevel;
+                        const filtered = levelFilter !== -1
+                            ? results.filter((r) => r.level === levelFilter)
+                            : results;
                         setRows((rows) => {
-                            if (rows.length > 1000 || results.length === 0) {
+                            if (rows.length > 1000 || filtered.length === 0) {
                                 return rows;
                             }
-                            return [...rows, ...results];
+                            return [...rows, ...filtered];
                         });
                     }),
                     proxy(setSearching)
@@ -761,6 +767,7 @@ export default function CalibrationForm({
                     wildLocation={calibrationFormState.wildLocation}
                     wildPokemon={calibrationFormState.wildPokemon}
                     wildLead={calibrationFormState.wildLead}
+                    wildLevel={calibrationFormState.wildLevel}
                     shouldFilterPokemon={
                         calibrationFormState.shouldFilterPokemon
                     }
@@ -770,7 +777,8 @@ export default function CalibrationForm({
                         wildLocation,
                         wildPokemon,
                         wildLead,
-                        shouldFilterPokemon
+                        shouldFilterPokemon,
+                        wildLevel
                     ) => {
                         setCalibrationFormState((data) => ({
                             ...data,
@@ -779,6 +787,7 @@ export default function CalibrationForm({
                             wildPokemon,
                             wildLead,
                             shouldFilterPokemon,
+                            wildLevel,
                         }));
                     }}
                 />

--- a/src/components/SearcherForm.tsx
+++ b/src/components/SearcherForm.tsx
@@ -39,6 +39,7 @@ export interface SearcherFormState {
     wildLocation: number;
     wildPokemon: number;
     wildLead: number;
+    wildLevel: number;
     method: number;
 }
 
@@ -96,6 +97,7 @@ export default function CalibrationForm({
             wildLocation: 0,
             wildPokemon: 0,
             wildLead: 255,
+            wildLevel: -1,
             method: 1,
         });
     const { game, trainerID, secretID, setSearcherURLState } =
@@ -164,11 +166,15 @@ export default function CalibrationForm({
                     searcherFormState.hiddenPower,
                     ivRanges,
                     proxy((results: ExtendedWildSearcherState[]) => {
+                        const levelFilter = searcherFormState.wildLevel;
+                        const filtered = levelFilter !== -1
+                            ? results.filter((r) => r.level === levelFilter)
+                            : results;
                         setRows((rows) => {
-                            if (rows.length > 1000 || results.length === 0) {
+                            if (rows.length > 1000 || filtered.length === 0) {
                                 return rows;
                             }
-                            return [...rows, ...results];
+                            return [...rows, ...filtered];
                         });
                     }),
                     proxy(setSearching)
@@ -307,13 +313,15 @@ export default function CalibrationForm({
                     wildLocation={searcherFormState.wildLocation}
                     wildPokemon={searcherFormState.wildPokemon}
                     wildLead={searcherFormState.wildLead}
+                    wildLevel={searcherFormState.wildLevel}
                     game={SEED_IDENTIFIER_TO_GAME[game]}
                     onChange={(
                         wildCategory,
                         wildLocation,
                         wildPokemon,
                         wildLead,
-                        _
+                        _,
+                        wildLevel
                     ) => {
                         setSearcherFormState((data) => ({
                             ...data,
@@ -321,6 +329,7 @@ export default function CalibrationForm({
                             wildLocation,
                             wildPokemon,
                             wildLead,
+                            wildLevel,
                         }));
                     }}
                     shouldFilterPokemon={true}

--- a/src/components/WildEncounterSelector.tsx
+++ b/src/components/WildEncounterSelector.tsx
@@ -16,6 +16,7 @@ function WildEncounterSelector({
     wildLocation,
     wildPokemon,
     wildLead,
+    wildLevel,
     shouldFilterPokemon,
     onChange,
     game = Game.Gen3,
@@ -26,13 +27,15 @@ function WildEncounterSelector({
     wildLocation: number;
     wildPokemon: number;
     wildLead: number;
+    wildLevel: number;
     shouldFilterPokemon: boolean;
     onChange: (
         wildCategory: number,
         wildLocation: number,
         wildPokemon: number,
         wildLead: number,
-        shouldFilterPokemon: boolean
+        shouldFilterPokemon: boolean,
+        wildLevel: number
     ) => void;
     game?: number;
     allowAnyPokemon?: boolean;
@@ -40,6 +43,7 @@ function WildEncounterSelector({
 }) {
     const [wildLocations, setWildLocations] = useState<number[]>([]);
     const [areaSpecies, setAreaSpecies] = useState<number[]>([]);
+    const [levelRange, setLevelRange] = useState<[number, number] | null>(null);
 
     useEffect(() => {
         const fetchWildLocations = async () => {
@@ -58,7 +62,8 @@ function WildEncounterSelector({
                     : 0,
                 wildPokemon,
                 wildLead,
-                shouldFilterPokemon
+                shouldFilterPokemon,
+                -1
             );
         };
         fetchWildLocations();
@@ -82,11 +87,30 @@ function WildEncounterSelector({
                     ? areaSpecies[0]
                     : 0,
                 wildLead,
-                shouldFilterPokemon
+                shouldFilterPokemon,
+                -1
             );
         };
         fetchAreaSpecies();
     }, [game, wildCategory, wildLocation]);
+
+    useEffect(() => {
+        if (wildPokemon === -1) {
+            setLevelRange(null);
+            return;
+        }
+        const fetchLevelRange = async () => {
+            const tenLines = await fetchTenLines();
+            const range = await tenLines.get_level_range(
+                game,
+                wildCategory,
+                wildLocation,
+                wildPokemon
+            );
+            setLevelRange([range[0], range[1]]);
+        };
+        fetchLevelRange();
+    }, [game, wildCategory, wildLocation, wildPokemon]);
 
     const isEmerald = (game & Game.Emerald) == Game.Emerald;
 
@@ -102,7 +126,8 @@ function WildEncounterSelector({
                         wildLocation,
                         wildPokemon,
                         wildLead,
-                        shouldFilterPokemon
+                        shouldFilterPokemon,
+                        -1
                     );
                 }}
                 value={wildCategory}
@@ -124,7 +149,8 @@ function WildEncounterSelector({
                         newValue,
                         wildPokemon,
                         wildLead,
-                        shouldFilterPokemon
+                        shouldFilterPokemon,
+                        -1
                     );
                 }}
                 getOptionLabel={(option) =>
@@ -150,7 +176,8 @@ function WildEncounterSelector({
                             wildLocation,
                             parseInt(event.target.value),
                             wildLead,
-                            shouldFilterPokemon
+                            shouldFilterPokemon,
+                            -1
                         );
                     }}
                     value={wildPokemon}
@@ -176,7 +203,8 @@ function WildEncounterSelector({
                                         wildLocation,
                                         wildPokemon,
                                         wildLead,
-                                        event.target.checked
+                                        event.target.checked,
+                                        wildLevel
                                     );
                                 }}
                             />
@@ -188,6 +216,36 @@ function WildEncounterSelector({
                     />
                 )}
             </Box>
+            {levelRange && levelRange[0] <= levelRange[1] && (
+                <TextField
+                    label="Level"
+                    margin="normal"
+                    style={{ textAlign: "left" }}
+                    onChange={(event) => {
+                        onChange(
+                            wildCategory,
+                            wildLocation,
+                            wildPokemon,
+                            wildLead,
+                            shouldFilterPokemon,
+                            parseInt(event.target.value)
+                        );
+                    }}
+                    value={wildLevel}
+                    select
+                    fullWidth
+                >
+                    <MenuItem value="-1">Any</MenuItem>
+                    {Array.from(
+                        { length: levelRange[1] - levelRange[0] + 1 },
+                        (_, i) => levelRange[0] + i
+                    ).map((level) => (
+                        <MenuItem key={level} value={level}>
+                            {level}
+                        </MenuItem>
+                    ))}
+                </TextField>
+            )}
             {isEmerald && (
                 <TextField
                     label="Lead"
@@ -199,7 +257,8 @@ function WildEncounterSelector({
                             wildLocation,
                             wildPokemon,
                             parseInt(event.target.value),
-                            shouldFilterPokemon
+                            shouldFilterPokemon,
+                            wildLevel
                         );
                     }}
                     value={wildLead}

--- a/src/wasm/src/fetch_util.cpp
+++ b/src/wasm/src/fetch_util.cpp
@@ -1,4 +1,5 @@
 #include "blisy_events.hpp"
+#include "pokefinder_glue.hpp"
 #include "util.hpp"
 #include <Core/Gen3/EncounterArea3.hpp>
 #include <Core/Gen3/Encounters3.hpp>
@@ -26,6 +27,14 @@ emscripten::typed_array<u16> get_area_species(u32 game, u8 encounter_category, u
     return area.getUniqueSpecies();
 }
 
+emscripten::typed_array<u8> get_level_range(u32 game, u8 encounter_category, u16 location, int pokemon)
+{
+    auto area = get_encounter_area(Encounter(encounter_category), location, Game(game));
+    u16 species = pokemon & 0x7ff;
+    auto [min_level, max_level] = area.getLevelRange(species);
+    return std::array<u8, 2> { min_level, max_level };
+}
+
 emscripten::typed_array<EnumeratedStaticTemplate3> get_static_template_info(int category)
 {
     if (category == BlisyEvents::CATEGORY) {
@@ -46,5 +55,6 @@ EMSCRIPTEN_BINDINGS(fetch_util)
 {
     emscripten::smart_function("get_wild_locations", &get_wild_locations);
     emscripten::smart_function("get_area_species", &get_area_species);
+    emscripten::smart_function("get_level_range", &get_level_range);
     emscripten::smart_function("get_static_template_info", &get_static_template_info);
 }


### PR DESCRIPTION
Reorganizing the branches in my fork so I can open multiple pull requests. This recreates #10. @lincoln-lm I wanted to filter by level when finding the pokemon I encountered. Let me know if I need to change anything

- Add get_level_range WASM binding to query PokeFinder's EncounterArea::getLevelRange for a given game, encounter category, location, and species. 
- Populate a Level dropdown in WildEncounterSelector with only valid levels. 
- Filter results on submit in both SearcherForm and CalibrationForm.