### PR TITLE
Add support for blackout L/R for NX versions

### DIFF
--- a/src/wasm/src/initial_seed.hpp
+++ b/src/wasm/src/initial_seed.hpp
@@ -253,6 +253,8 @@ static inline std::map<std::string, std::vector<HeldButtonOffset>> HELD_BUTTON_O
             { 'a', "none", 0 },
 
             { 'h', "none", 0 },
+            { 'h', "blackout_r", -36 },
+            { 'h', "blackout_l", -36 },
 
             { 'r', "none", 0 },
         } },
@@ -262,6 +264,8 @@ static inline std::map<std::string, std::vector<HeldButtonOffset>> HELD_BUTTON_O
             { 'a', "none", 0 },
 
             { 'h', "none", 0 },
+            { 'h', "blackout_r", -36 },
+            { 'h', "blackout_l", -36 },
 
             { 'r', "none", 0 },
         } },


### PR DESCRIPTION
Added blackout L & blackout R offsets for both NX versions when button setting is "help", according to @papajefe's testing.
Closes #15 