### PR TITLE
Make target seed dropdown list center around current target seed

### DIFF
--- a/src/components/CalibrationForm.tsx
+++ b/src/components/CalibrationForm.tsx
@@ -540,7 +540,12 @@ export default function CalibrationForm({
                         gameConsole
                     )}ms)`;
                 }}
-                filterOptions={targetSeedFilterOptions}
+                filterOptions={(option, _) => targetSeedFilterOptions(option.slice(
+                    Math.max(targetSeedIndex - 50, 0),
+                    Math.min(
+                        targetSeedIndex + 50,
+                        seedList.length
+                    )), _)}
                 renderInput={(params) => (
                     <TextField
                         {...params}

--- a/src/components/CalibrationForm.tsx
+++ b/src/components/CalibrationForm.tsx
@@ -526,7 +526,14 @@ export default function CalibrationForm({
                     ]
                 }</TextField>
             <Autocomplete
-                options={seedList}
+                options={seedList.slice(
+                        Math.max(targetSeedIndex - 50, 0), 
+                        Math.min(targetSeedIndex + 50, seedList.length)
+                    ).concat(
+                        seedList.slice(0, Math.max(targetSeedIndex - 51, 0))
+                    ).concat(
+                        seedList.slice(Math.min(targetSeedIndex + 51, seedList.length), seedList.length)
+                    )}
                 value={targetSeed}
                 onChange={(_event, newValue) => {
                     setCalibrationURLState({
@@ -540,12 +547,7 @@ export default function CalibrationForm({
                         gameConsole
                     )}ms)`;
                 }}
-                filterOptions={(option, _) => targetSeedFilterOptions(option.slice(
-                    Math.max(targetSeedIndex - 50, 0),
-                    Math.min(
-                        targetSeedIndex + 50,
-                        seedList.length
-                    )), _)}
+                filterOptions={targetSeedFilterOptions}
                 renderInput={(params) => (
                     <TextField
                         {...params}

--- a/src/components/CalibrationForm.tsx
+++ b/src/components/CalibrationForm.tsx
@@ -530,9 +530,9 @@ export default function CalibrationForm({
                         Math.max(targetSeedIndex - 50, 0), 
                         Math.min(targetSeedIndex + 50, seedList.length)
                     ).concat(
-                        seedList.slice(0, Math.max(targetSeedIndex - 51, 0))
+                        seedList.slice(0, Math.max(targetSeedIndex - 50, 0))
                     ).concat(
-                        seedList.slice(Math.min(targetSeedIndex + 51, seedList.length), seedList.length)
+                        seedList.slice(Math.min(targetSeedIndex + 50, seedList.length), seedList.length)
                     )}
                 value={targetSeed}
                 onChange={(_event, newValue) => {


### PR DESCRIPTION
The `filterOption` for `targetSeed` did not account for current target seed and always used the complete `seedList` for the dropdown menu, hence always starting from the earliest seed in the list and only listing the first 100 seeds. This feeds a sliced-down `seedList` instead, centered around the current target seed.
Closes #8 

Might still need some work, as it currently makes the search dis-ordered, I could not yet find an elegant solution to have both the displayed list centered around the currently selected target and the whole list searchable without reworking the core working of `filterOptions`.