### PR TITLE
Fix IV Calculator off-by-one in missing stat detection

### DIFF
--- a/src/components/IvCalculator.tsx
+++ b/src/components/IvCalculator.tsx
@@ -30,8 +30,8 @@ function IvCalculator({
         const lines = value.split("\n");
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            const lineEntries = line.split(" ");
-            if (line == "") return `Line ${i + 1} Missing Level`;
+            const lineEntries = line.split(" ").filter((s) => s !== "");
+            if (lineEntries.length == 0) return `Line ${i + 1} Missing Level`;
             const level = parseInt(lineEntries[0]) ?? 0;
             if (level > 100 || level < 1) return `Line ${i + 1} Invalid Level`;
             if (lineEntries.length == 1) return `Line ${i + 1} Missing HP`;


### PR DESCRIPTION
## Summary
- Fixed IV Calculator reporting the wrong missing stat when trailing spaces are present in input
- `line.split(" ")` produces empty string entries for trailing/extra spaces, inflating the entry count and skipping validation for the correct stat (e.g. `"5 "` would show "Missing Attack" instead of "Missing HP")
- Fix: filter empty strings from the split result before checking entry count

## Test plan
- [ ] Enter `5` in the IV Calculator — should show "Missing HP"
- [ ] Enter `5 ` (with trailing space) — should still show "Missing HP"
- [ ] Enter `5 100` — should show "Missing Attack"
- [ ] Enter a complete valid line — error should clear