### PR TITLE
IV Calculator Bug Fix

### DIFF
--- a/src/components/IvCalculator.tsx
+++ b/src/components/IvCalculator.tsx
@@ -30,8 +30,8 @@ function IvCalculator({
         const lines = value.split("\n");
         for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
-            const lineEntries = line.split(" ");
-            if (line == "") return `Line ${i + 1} Missing Level`;
+            const lineEntries = line.split(" ").filter((s) => s !== "");
+            if (lineEntries.length == 0) return `Line ${i + 1} Missing Level`;
             const level = parseInt(lineEntries[0]) ?? 0;
             if (level > 100 || level < 1) return `Line ${i + 1} Invalid Level`;
             if (lineEntries.length == 1) return `Line ${i + 1} Missing HP`;


### PR DESCRIPTION
Fixed a bug in the IV Calculator where an empty string would be considered as a valid split of a string, leading to the incorrect error message showing up for the user